### PR TITLE
Rc.1.5.1

### DIFF
--- a/hooks/opencps-hook/docroot/WEB-INF/src/content/Language_vi.properties
+++ b/hooks/opencps-hook/docroot/WEB-INF/src/content/Language_vi.properties
@@ -825,7 +825,7 @@ isEmployer = C\u00F3 qu\u1EA3n l\u00FD nh\u00E2n vi\u00EAn
 
 item-code = M\u00E3 danh m\u1EE5c
 
-item-name = M\u00E3 danh m\u1EE5c
+item-name = T\u00EAn danh m\u1EE5c
 
 items-per-page = b\u1EA3n ghi tr\u00EAn trang
 
@@ -1389,6 +1389,8 @@ servicr-outdate = H\u1EBFt h\u1EA1n
 short-name = T\u00EAn vi\u1EBFt t\u1EAFt
 
 business-shortname = T\u00EAn  vi\u1EBFt t\u1EAFt
+
+gov-code = Ch\u1ECDn c\u01A1 quan th\u1EF1c hi\u1EC7n
 
 shortName = T\u00EAn vi\u1EBFt t\u1EAFt
 

--- a/portlets/opencps-portlet/docroot/WEB-INF/src/content/Language_1_vi.properties
+++ b/portlets/opencps-portlet/docroot/WEB-INF/src/content/Language_1_vi.properties
@@ -23,7 +23,7 @@ inuse = \u0110ang s\u1EED d\u1EE5ng
 
 item-code = M\u00E3 danh m\u1EE5c
 
-item-name = M\u00E3 danh m\u1EE5c
+item-name = T\u00EAn danh m\u1EE5c
 
 javax.portlet.description = Qu\u1EA3n l\u00FD d\u1EEF li\u1EC7u danh m\u1EE5c
 javax.portlet.short-title = Qu\u1EA3n l\u00FD d\u1EEF li\u1EC7u danh m\u1EE5c

--- a/portlets/opencps-portlet/docroot/html/portlets/data_management/admin/edit_dictitem.jsp
+++ b/portlets/opencps-portlet/docroot/html/portlets/data_management/admin/edit_dictitem.jsp
@@ -85,16 +85,16 @@
 			<aui:input name="redirectURL" type="hidden" value="<%=backURL %>"/>
 			<aui:input name="returnURL" type="hidden" value="<%=currentURL %>"/>
 			<aui:fieldset>
+				
+				<aui:input name="<%=DictItemDisplayTerms.ITEM_CODE%>" type="text" cssClass="input20">
+					<aui:validator name="required"/>
+					<aui:validator name="maxLength">100</aui:validator> 
+				</aui:input>
 			
 				<aui:input name="<%=DictItemDisplayTerms.ITEM_NAME %>" cssClass="input80" label="item-name">
 					<aui:validator name="required"/>
 					<aui:validator name="minLength">3</aui:validator>
 					<aui:validator name="maxLength">255</aui:validator>
-				</aui:input>
-				
-				<aui:input name="<%=DictItemDisplayTerms.ITEM_CODE%>" type="text" cssClass="input20">
-					<aui:validator name="required"/>
-					<aui:validator name="maxLength">100</aui:validator> 
 				</aui:input>
 				
 				<aui:select name="<%=DictItemDisplayTerms.DICTCOLLECTION_ID %>" label="dict-collection">


### PR DESCRIPTION
- Sửa lỗi tên dictitem đang bị việt hóa nhầm sang mã
- đổi chỗ ô nhập mã, tên dictitem
- định nghĩa gov-code = cơ quan thực hiện
