### PR TITLE
Sửa lỗi luôn trả về trạng thái hồ sơ mới #927

### DIFF
--- a/portlets/opencps-portlet/docroot/WEB-INF/src/org/opencps/dossiermgt/search/DossierDisplayTerms.java
+++ b/portlets/opencps-portlet/docroot/WEB-INF/src/org/opencps/dossiermgt/search/DossierDisplayTerms.java
@@ -125,7 +125,7 @@ public class DossierDisplayTerms extends DisplayTerms {
 
 		dossierStatus = ParamUtil
 			.getString(portletRequest, DOSSIER_STATUS,
-				PortletConstants.DOSSIER_STATUS_NEW);
+				StringPool.BLANK);
 
 		serviceDomainCode = ParamUtil
 			.getString(portletRequest, SERVICE_DOMAIN_CODE);

--- a/portlets/opencps-portlet/docroot/WEB-INF/src/org/opencps/dossiermgt/search/DossierSearchTerms.java
+++ b/portlets/opencps-portlet/docroot/WEB-INF/src/org/opencps/dossiermgt/search/DossierSearchTerms.java
@@ -46,7 +46,7 @@ public class DossierSearchTerms extends DossierDisplayTerms {
 				.getDateTimeFormat(DateTimeUtil._VN_DATE_TIME_FORMAT));
 		dossierStatus = ParamUtil
 			.getString(portletRequest, DOSSIER_STATUS,
-				PortletConstants.DOSSIER_STATUS_NEW);
+				StringPool.BLANK);
 
 		serviceName = DAOParamUtil
 			.getString(portletRequest, SERVICE_NAME);


### PR DESCRIPTION
Trên trang tim kiếm hồ sơ công dân/doanh nghiệp(giao diện default) , trạng thái hồ sơ mặc định là mới
Sửa sang tìm tất cả
